### PR TITLE
issue#4: ruff lint check and fix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from fastapi import FastAPI
-import uvicorn
 
 app = FastAPI()
 


### PR DESCRIPTION
#4 
issue4-missed-ruff-linting

fix: removed the unused uvicorn import

Closes #4 
