### PR TITLE
issue #6: move port env var conf to docker run command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ COPY ./requirements-production.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src .
-ENV PORT=5001
 ENTRYPOINT uvicorn main:app --reload --host 0.0.0.0 --port $PORT

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ python -m unittest discover -s tests
 
 1. Open the project in VSCode.
 2. Open a VSCode Terminal at the root of the project. Then run these commands:
-   ```bash
-   docker build -t fastapi-app .
-   docker run -d -p <EXTERNAL_PORT>:<INTERNAL_PORT> fastapi-app
+```bash
+docker build -t fastapi-app .
+docker run -d -p <EXTERNAL_PORT>:<INTERNAL_PORT> -e PORT=<INTERNAL_PORT> fastapi-app
+```
 - <EXTERNAL_PORT>: The port on your machine/host you want to access the app through.
 - <INTERNAL_PORT>: The port inside the Docker container (set in the `Dockerfile`).
 3. Visit `http://localhost:<EXTERNAL_PORT>/` in your browser to see the current Unix timestamp returned by the FastAPI app.


### PR DESCRIPTION
#6
issue6-configure-port-at-command-level

Moved port environment variable configuration from dockerfile to docker run command

Closes #6